### PR TITLE
Update tweets.vue.js

### DIFF
--- a/app/tweets/tweets.vue.js
+++ b/app/tweets/tweets.vue.js
@@ -21,7 +21,7 @@
     });
 
     Vue.filter('tw-clock', function (value) {
-        const dateOfTweet = moment(value, "ddd MMM DD HH:mm:ss +ZZ YYYY");
+        const dateOfTweet = moment(value, "ddd MMM DD HH:mm:ss ZZ YYYY");
         return moment().locale("fr").to(dateOfTweet);
     });
 


### PR DESCRIPTION
Le format pour la Timezone doit être ZZ et non +ZZ. 

Avec l'ancienne valeure, il y avait un décalage de 2 heures. 